### PR TITLE
Update btr-bagit-profile

### DIFF
--- a/btr-bagit-profile.json
+++ b/btr-bagit-profile.json
@@ -43,17 +43,12 @@
             "required": false,
             "recommended": true,
             "description": "Can be the same as source_organization recommended when not the same as source"
-        },
-        "Data-Export-Info": {"required": false},
-        "Data-Export-Agent": {"required": false},
-        "Data-Export-Agent-Version": {"required": false},
-        "Data-Export-Format": {"required": false},
-        "Data-Export-Format-Version": {"required": false},
-        "Relationship-Info": {"required": false}
+        }
     },
     "Manifests-Required": [],
-    "Manifests-Supported": [
+    "Manifests-Allowed": [
         "md5",
+        "sha1",
         "sha256",
         "sha512"
     ],
@@ -62,11 +57,13 @@
     "Accept-Serialization": [
         "application/zip",
         "application/x-tar",
-        "application/gzip"
+        "application/gzip",
+        "application/x-7z-compressed"
     ],
     "Tag-Manifests-Required": [],
-    "Tag-Manifests-Supported": [
+    "Tag-Manifests-Allowed": [
         "md5",
+        "sha1",
         "sha256",
         "sha512"
     ],


### PR DESCRIPTION
changes based on BtR advisory board meeting at NWU on Tuesday August 27, 2017
see https://docs.google.com/document/d/1QXLbvEqUS5GGfH7CozcyvX_om8w_xOTH0psmNWCATzM/edit

list of changes:

- add 7z mimetype to `Accept-Serialization` list (to allow easier support of Archivematica AIPs)
- change `Manifests-Supported` to `Manifests-Allowed`
- change `Tag-Manifests-Supported` to `Tag-Manifests-Allowed`
- add `sha1` to both `Manifests-Allowed` and `Tag-Manifests-Allowed`
- remove the `Data-Export-*` tags (they will be described in defiintions as examples or suggestions)
- remove `Relationship-Info`
