### PR TITLE
Two proposed changes: "application/tar" and "capabilities" 

### DIFF
--- a/btr-bagit-profile.json
+++ b/btr-bagit-profile.json
@@ -56,7 +56,9 @@
     "Accept-Serialization": [
         "application/zip",
         "application/tar",
+        "application/x-tar",
         "application/gzip",
+        "application/x-gzip",
         "application/x-7z-compressed"
     ],
     "Tag-Manifests-Required": [],

--- a/btr-bagit-profile.json
+++ b/btr-bagit-profile.json
@@ -3,7 +3,7 @@
         "Source-Organization": "Beyond the Repository Bagit Profile Group",
         "External-Description": "Bagit Profile for Consistent Deposit to Distributed Digital Preservation Services",
         "Version": "0.1",
-        "BagIt-Profile-Identifier": "http://????/???-v0.1.json", 
+        "BagIt-Profile-Identifier": "http://????/???-v0.1.json",
         "BagIt-Profile-Version": "1.2.0",
         "Contact-Name": "Hope Fully Apersonsname",
         "Contact-Phone": "(we probably don't want this)",
@@ -14,7 +14,7 @@
         }
     },
     "Bag-Info": {
-        "Source-Organization": {"required": true, "capabilities": ["searchable"]},
+        "Source-Organization": {"required": true},
         "Bagging-Date": {"required": true},
         "Payload-Oxum": {"required": true},
         "Bagit-Profile-Identifier": {"required": true},
@@ -27,8 +27,7 @@
         "Bag-Group-Identifier": {
             "required": false,
             "recommended": true,
-            "description": "*Recommended in the case of multiple related bags, otherwise optional",
-            "capabilities": ["searchable"]
+            "description": "*Recommended in the case of multiple related bags, otherwise optional"
         },
         "Bag-Count": {
             "required": false,
@@ -36,8 +35,8 @@
             "description": "*Recommended in the case of multiple related bags, otherwise optional"
         },
         "Bag-Size": {"required": false},
-        "Internal-Sender-Identifier": {"required": false, "recommended": true, "capabilities": ["searchable"]},
-        "Internal-Sender-Description": {"required": false, "recommended": true, "capabilities": ["searchable"]},
+        "Internal-Sender-Identifier": {"required": false, "recommended": true},
+        "Internal-Sender-Description": {"required": false, "recommended": true},
         "Payload-Identifier": {"required": false},
         "Bag-Producing-Organization": {
             "required": false,
@@ -56,7 +55,7 @@
     "Serialization": "optional",
     "Accept-Serialization": [
         "application/zip",
-        "application/x-tar",
+        "application/tar",
         "application/gzip",
         "application/x-7z-compressed"
     ],
@@ -74,4 +73,3 @@
         "1.0"
     ]
 }
-

--- a/btr-bagit-profile.json
+++ b/btr-bagit-profile.json
@@ -4,7 +4,7 @@
         "External-Description": "Bagit Profile for Consistent Deposit to Distributed Digital Preservation Services",
         "Version": "0.1",
         "BagIt-Profile-Identifier": "http://????/???-v0.1.json",
-        "BagIt-Profile-Version": "1.2.0",
+        "BagIt-Profile-Version": "1.3.0",
         "Contact-Name": "Hope Fully Apersonsname",
         "Contact-Phone": "(we probably don't want this)",
         "Contact-Email": "fake-email@example.com",


### PR DESCRIPTION
In the Accept-Serialization list, I changed application/x-tar to application/tar. Both are acceptable, but both the main bagit-profiles repo and DART use application/tar.

I also removed the capabilities attribute from tag definitions because that attribute describes things the receiving repository should implement. "Capabilities" has nothing to do with the bag or its contents.
