### PR TITLE
Removes BtR-Extensions section

### DIFF
--- a/btr-bagit-profile.json
+++ b/btr-bagit-profile.json
@@ -7,11 +7,7 @@
         "BagIt-Profile-Version": "1.2.0",
         "Contact-Name": "Hope Fully Apersonsname",
         "Contact-Phone": "(we probably don't want this)",
-        "Contact-Email": "fake-email@example.com",
-        "BtR-Extensions": {
-            "Recommended-Tags": ["Organization-Address", "Contact-Email", "Bag-Group-Identifier", "Bag-Count", "Internal-Sender-Identifier", "Internal-Sender-Description", "Bagit-Profile-Identifier"],
-            "Searchable-Tags": ["Source-Organization", "Bag-Group-Identifier", "Internal-Sender-Identifier", "Internal-Sender-Description"]
-        }
+        "Contact-Email": "fake-email@example.com"
     },
     "Bag-Info": {
         "Source-Organization": {"required": true, "capabilities": ["searchable"]},


### PR DESCRIPTION
As noted in https://github.com/dpscollaborative/btr_bagit_profile/pull/2, the ability to search specific tags in a system that happens to ingest a bag doesn't seem to fit as part of the bag profile spec as it has nothing to do with the transfer of data.

The list of recommended tags duplicates the `"recommended": true` property associated with the individual tags. Given that this doesn't provide any additional information, and future edits may only update one of the two locations (causing the two data sources to become out-of-sync), it seems best to leave this out.

Dropping this section also means that we don't tie anything in this profile to the "BtR" grant by name, which seems desirable for longevity.