### PR TITLE
removed Bagit-Profile-Identifier from Bag-Info section

### DIFF
--- a/btr-bagit-profile.json
+++ b/btr-bagit-profile.json
@@ -17,7 +17,6 @@
         "Source-Organization": {"required": true, "capabilities": ["searchable"]},
         "Bagging-Date": {"required": true},
         "Payload-Oxum": {"required": true},
-        "Bagit-Profile-Identifier": {"required": true},
         "Organization-Address": {"required": false, "recommended": true},
         "Contact-Name": {"required": false},
         "Contact-Phone": {"required": false},


### PR DESCRIPTION
Based on current version of the bagit-profile spec, "The tag BagIt-Profile-Identifier is always required, but SHOULD NOT be listed under Bag-Info in the profile." I removed it from our profile.